### PR TITLE
Fix: persist updatedAt on document updates (fixes #50)

### DIFF
--- a/lib/AuthoredModule.js
+++ b/lib/AuthoredModule.js
@@ -57,7 +57,9 @@ class AuthoredModule extends AbstractModule {
 
     mod.requestHook.tap(this.updateAuthor, this)
     mod.preInsertHook.tap((insertData) => this.updateTimestamps('insert', insertData))
-    mod.preUpdateHook.tap((ogDoc, updateData) => this.updateTimestamps('update', { ...updateData, _courseId: updateData._courseId ?? ogDoc._courseId }))
+    // pass the real updateData so updatedAt lands on the written $set; the
+    // course id is passed separately so it isn't injected into the document
+    mod.preUpdateHook.tap((ogDoc, updateData) => this.updateTimestamps('update', updateData, updateData._courseId ?? ogDoc._courseId))
     mod.preDeleteHook.tap((ogDoc) => this.updateCourseTimestamp(ogDoc))
   }
 
@@ -98,13 +100,14 @@ class AuthoredModule extends AbstractModule {
   /**
    * Function to update authored timestamp on data change
    * @param {String} action
-   * @param {Object} data
+   * @param {Object} data The data being written (mutated in place)
+   * @param {String} [courseId] Course to bump, when not present on `data`
    * @return {Promise}
    */
-  async updateTimestamps (action, data) {
+  async updateTimestamps (action, data, courseId = data._courseId) {
     data.updatedAt = new Date().toISOString()
     if (action === 'insert') data.createdAt = data.updatedAt
-    await this.updateCourseTimestamp(data)
+    await this.updateCourseTimestamp({ _courseId: courseId })
   }
 
   async updateCourseTimestamp (data) {

--- a/tests/AuthoredModule.spec.js
+++ b/tests/AuthoredModule.spec.js
@@ -183,6 +183,33 @@ describe('AuthoredModule', () => {
       // extendSchema should be called at least once via registerSchemas
       assert.ok(mockJsonschema.extendSchema.mock.calls.length >= 1)
     })
+
+    it('should set updatedAt on the real update data via the preUpdateHook tap', async () => {
+      const { instance } = createInstance()
+      const mod = createMockMod()
+      await instance.registerModule(mod)
+
+      const onUpdate = mod.preUpdateHook.tap.mock.calls[0].arguments[0]
+      const updateData = { title: 'x' }
+      await onUpdate({}, updateData)
+
+      // the object that gets written must receive updatedAt (regression: it was
+      // set on a discarded spread copy), and _courseId must not be injected
+      assert.ok(updateData.updatedAt, 'updatedAt set on the written update data')
+      assert.equal(updateData._courseId, undefined, '_courseId not injected into the document')
+    })
+
+    it('should bump the course using the original doc id when absent on the update', async () => {
+      const { instance } = createInstance()
+      const mod = createMockMod()
+      await instance.registerModule(mod)
+
+      const onUpdate = mod.preUpdateHook.tap.mock.calls[0].arguments[0]
+      await onUpdate({ _courseId: 'course1' }, { title: 'x' })
+
+      assert.equal(instance.courseCache.get.mock.calls.length, 1)
+      assert.deepEqual(instance.courseCache.get.mock.calls[0].arguments[0], { _type: 'course', _courseId: 'course1' })
+    })
   })
 
   describe('#registerSchemas()', () => {


### PR DESCRIPTION
### Fixes #50

### Fix
- `registerModule`'s `preUpdateHook` tap now passes the **real** update data to `updateTimestamps`, so `updatedAt` lands on the written `$set` instead of a discarded spread copy.
- The course id is passed to `updateTimestamps` as a separate argument, so `_courseId` is no longer injected into the updated document.
- Restores per-document `updatedAt` on **update** for all authored collections (content items, assets, …). Previously only inserts set it, and a course's own timestamp was bumped via a separate direct write — which masked the bug for content and left assets' `updatedAt` never changing.

### Testing
- Added regression tests that invoke the `preUpdateHook` tap and assert `updatedAt` is set on the passed object (and `_courseId` isn't injected), plus the course-id fallback from the original doc.
- `npx standard` clean; `npm test` 33/33 pass.

> Heads-up: this changes observable behaviour — per-item `updatedAt` now actually updates on edits. Anything that (perhaps unknowingly) relied on the old static value should be checked.