### PR TITLE
New: add updatedBy attribution and a recent-changes query helper (fixes #53)

### DIFF
--- a/lib/AuthoredModule.js
+++ b/lib/AuthoredModule.js
@@ -1,4 +1,5 @@
 import { AbstractModule, DataCache } from 'adapt-authoring-core'
+import { buildRecentlyChangedPipeline } from './utils.js'
 /**
  * Add supplementary data to existing schemas which defines how and when data was authored
  * @memberof authored
@@ -60,7 +61,8 @@ class AuthoredModule extends AbstractModule {
     // pass the real updateData so updatedAt lands on the written $set; the
     // course id is passed separately so it isn't injected into the document
     mod.preUpdateHook.tap((ogDoc, updateData) => this.updateTimestamps('update', updateData, updateData._courseId ?? ogDoc._courseId))
-    mod.preDeleteHook.tap((ogDoc) => this.updateCourseTimestamp(ogDoc))
+    // deletes carry no acting user, so bump the course timestamp only (no updatedBy)
+    mod.preDeleteHook.tap((ogDoc) => this.updateCourseTimestamp({ _courseId: ogDoc._courseId }))
   }
 
   /**
@@ -82,6 +84,7 @@ class AuthoredModule extends AbstractModule {
    */
   async updateAuthor (req) {
     if (!req.apiData.modifying) return
+    if (req.auth?.user) req.apiData.data.updatedBy = req.auth.user._id.toString()
     if (req.method === 'POST' && !req.apiData.data.createdBy) {
       req.apiData.data.createdBy = req.auth.user._id.toString()
       return
@@ -107,7 +110,7 @@ class AuthoredModule extends AbstractModule {
   async updateTimestamps (action, data, courseId = data._courseId) {
     data.updatedAt = new Date().toISOString()
     if (action === 'insert') data.createdAt = data.updatedAt
-    await this.updateCourseTimestamp({ _courseId: courseId })
+    await this.updateCourseTimestamp({ _courseId: courseId, updatedBy: data.updatedBy })
   }
 
   async updateCourseTimestamp (data) {
@@ -119,7 +122,24 @@ class AuthoredModule extends AbstractModule {
     )
     if (!course) return
     const mongodb = await this.app.waitForModule('mongodb')
-    await mongodb.update('content', { _id: course._id }, { $set: { updatedAt: new Date().toISOString() } })
+    const $set = { updatedAt: new Date().toISOString() }
+    if (data.updatedBy) $set.updatedBy = data.updatedBy
+    await mongodb.update('content', { _id: course._id }, { $set })
+  }
+
+  /**
+   * Returns the most-recently-changed documents across all registered collections, newest first
+   * @param {Object} options
+   * @param {Number} options.limit Maximum number of rows to return
+   * @param {Object} options.filters Per-collection match query keyed by collection name (e.g. access filters)
+   * @return {Promise<Array>} Rows of { _id, collection, createdAt, updatedAt, createdBy, updatedBy }
+   */
+  async getRecentlyChanged ({ limit = 25, filters = {} } = {}) {
+    const collections = this.registeredModules.map(m => m.collectionName).filter(Boolean)
+    if (!collections.length) return []
+    const pipeline = buildRecentlyChangedPipeline(collections, { limit, filters })
+    const mongodb = await this.app.waitForModule('mongodb')
+    return mongodb.getCollection(collections[0]).aggregate(pipeline).toArray()
   }
 }
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,0 +1,1 @@
+export { default as buildRecentlyChangedPipeline } from './utils/buildRecentlyChangedPipeline.js'

--- a/lib/utils/buildRecentlyChangedPipeline.js
+++ b/lib/utils/buildRecentlyChangedPipeline.js
@@ -1,0 +1,32 @@
+/**
+ * Builds an aggregation pipeline returning the most-recently-changed documents
+ * across several collections, newest first. The first collection is the
+ * aggregation base; the rest are unioned in.
+ * @param {Array} collections Collection names to union (non-empty)
+ * @param {Object} options
+ * @param {Number} options.limit Maximum number of rows to return
+ * @param {Object} options.filters Per-collection match query keyed by collection name
+ * @return {Array} The aggregation pipeline
+ */
+export default function buildRecentlyChangedPipeline (collections, { limit = 25, filters = {} } = {}) {
+  const branch = name => [
+    { $match: filters[name] ?? {} },
+    {
+      $project: {
+        _id: 1,
+        collection: { $literal: name },
+        createdAt: 1,
+        updatedAt: 1,
+        createdBy: 1,
+        updatedBy: 1
+      }
+    }
+  ]
+  const [base, ...rest] = collections
+  return [
+    ...branch(base),
+    ...rest.map(name => ({ $unionWith: { coll: name, pipeline: branch(name) } })),
+    { $sort: { updatedAt: -1 } },
+    { $limit: limit }
+  ]
+}

--- a/schema/authored.schema.json
+++ b/schema/authored.schema.json
@@ -21,6 +21,11 @@
           "type": "string",
           "format": "date-time",
           "isDate": true
+        },
+        "updatedBy": {
+          "description": "User who last modified the data",
+          "type": "string",
+          "isObjectId": true
         }
       },
       "required": ["createdAt","createdBy","updatedAt"]

--- a/tests/AuthoredModule.spec.js
+++ b/tests/AuthoredModule.spec.js
@@ -210,6 +210,18 @@ describe('AuthoredModule', () => {
       assert.equal(instance.courseCache.get.mock.calls.length, 1)
       assert.deepEqual(instance.courseCache.get.mock.calls[0].arguments[0], { _type: 'course', _courseId: 'course1' })
     })
+
+    it('should bump the course with only the course id on delete (no stale updatedBy)', async () => {
+      const { instance } = createInstance()
+      const mod = createMockMod()
+      await instance.registerModule(mod)
+      instance.updateCourseTimestamp = mock.fn(async () => {})
+
+      const onDelete = mod.preDeleteHook.tap.mock.calls[0].arguments[0]
+      await onDelete({ _courseId: 'course1', updatedBy: 'oldEditor' })
+
+      assert.deepEqual(instance.updateCourseTimestamp.mock.calls[0].arguments[0], { _courseId: 'course1' })
+    })
   })
 
   describe('#registerSchemas()', () => {
@@ -452,6 +464,42 @@ describe('AuthoredModule', () => {
 
       assert.equal(inst.userCache.get.mock.calls.length, 0)
     })
+
+    it('should set updatedBy to the acting user on a modifying POST', async () => {
+      const req = {
+        method: 'POST',
+        apiData: { modifying: true, data: {} },
+        auth: { user: { _id: { toString: () => 'user123' } } }
+      }
+
+      await instance.updateAuthor(req)
+
+      assert.equal(req.apiData.data.updatedBy, 'user123')
+    })
+
+    it('should set updatedBy to the acting user on a modifying non-POST', async () => {
+      const req = {
+        method: 'PUT',
+        apiData: { modifying: true, data: {} },
+        auth: { user: { _id: { toString: () => 'editor9' } } }
+      }
+
+      await instance.updateAuthor(req)
+
+      assert.equal(req.apiData.data.updatedBy, 'editor9')
+    })
+
+    it('should not set updatedBy when not modifying', async () => {
+      const req = {
+        method: 'POST',
+        apiData: { modifying: false, data: {} },
+        auth: { user: { _id: { toString: () => 'user123' } } }
+      }
+
+      await instance.updateAuthor(req)
+
+      assert.equal(req.apiData.data.updatedBy, undefined)
+    })
   })
 
   describe('#updateTimestamps()', () => {
@@ -501,6 +549,14 @@ describe('AuthoredModule', () => {
       await instance.updateTimestamps('update', data)
 
       assert.ok(instance.courseCache.get.mock.calls.length > 0)
+    })
+
+    it('should thread updatedBy from the write data through to the course bump', async () => {
+      instance.courseCache = createMockCache([{ _id: 'course1' }])
+      await instance.updateTimestamps('update', { _courseId: 'course1', updatedBy: 'editor9' })
+
+      const { $set } = mockMongodb.update.mock.calls[0].arguments[2]
+      assert.equal($set.updatedBy, 'editor9')
     })
   })
 
@@ -560,6 +616,86 @@ describe('AuthoredModule', () => {
 
       assert.equal(instance.courseCache.get.mock.calls.length, 0)
       assert.equal(mockMongodb.update.mock.calls.length, 0)
+    })
+
+    it('should stamp updatedBy on the course when provided', async () => {
+      const mockMongodb = { update: mock.fn(async () => {}) }
+      const { instance } = createInstance({
+        waitForModule: mock.fn(async () => mockMongodb)
+      })
+      instance.courseCache = createMockCache([{ _id: 'course1' }])
+
+      await instance.updateCourseTimestamp({ _courseId: 'course1', updatedBy: 'editor9' })
+
+      const { $set } = mockMongodb.update.mock.calls[0].arguments[2]
+      assert.ok($set.updatedAt)
+      assert.equal($set.updatedBy, 'editor9')
+    })
+
+    it('should not stamp updatedBy on the course when absent (e.g. deletes)', async () => {
+      const mockMongodb = { update: mock.fn(async () => {}) }
+      const { instance } = createInstance({
+        waitForModule: mock.fn(async () => mockMongodb)
+      })
+      instance.courseCache = createMockCache([{ _id: 'course1' }])
+
+      await instance.updateCourseTimestamp({ _courseId: 'course1' })
+
+      const { $set } = mockMongodb.update.mock.calls[0].arguments[2]
+      assert.ok($set.updatedAt)
+      assert.equal('updatedBy' in $set, false)
+    })
+  })
+
+  describe('#getRecentlyChanged()', () => {
+    function createMongodbMock (rows = []) {
+      const toArray = mock.fn(async () => rows)
+      const aggregate = mock.fn(() => ({ toArray }))
+      const getCollection = mock.fn(() => ({ aggregate }))
+      return { getCollection, aggregate, toArray }
+    }
+
+    it('should return an empty array when no modules are registered', async () => {
+      const { instance } = createInstance()
+      instance.registeredModules = []
+
+      assert.deepEqual(await instance.getRecentlyChanged(), [])
+    })
+
+    it('should aggregate over the registered collections and return the rows', async () => {
+      const mongodb = createMongodbMock([{ _id: 'a', collection: 'content' }])
+      const { instance } = createInstance({ waitForModule: mock.fn(async () => mongodb) })
+      instance.registeredModules = [{ collectionName: 'content' }, { collectionName: 'assets' }]
+
+      const rows = await instance.getRecentlyChanged({ limit: 10 })
+
+      assert.deepEqual(rows, [{ _id: 'a', collection: 'content' }])
+      assert.equal(mongodb.getCollection.mock.calls[0].arguments[0], 'content')
+      const pipeline = mongodb.aggregate.mock.calls[0].arguments[0]
+      assert.equal(pipeline.filter(s => s.$unionWith).length, 1)
+      assert.deepEqual(pipeline.at(-1), { $limit: 10 })
+    })
+
+    it('should pass per-collection filters into the pipeline', async () => {
+      const mongodb = createMongodbMock()
+      const { instance } = createInstance({ waitForModule: mock.fn(async () => mongodb) })
+      instance.registeredModules = [{ collectionName: 'content' }]
+
+      await instance.getRecentlyChanged({ filters: { content: { _type: 'course' } } })
+
+      const pipeline = mongodb.aggregate.mock.calls[0].arguments[0]
+      assert.deepEqual(pipeline[0].$match, { _type: 'course' })
+    })
+
+    it('should ignore registered modules without a collectionName', async () => {
+      const mongodb = createMongodbMock()
+      const { instance } = createInstance({ waitForModule: mock.fn(async () => mongodb) })
+      instance.registeredModules = [{ collectionName: 'content' }, { schemaName: 'noCollection' }]
+
+      await instance.getRecentlyChanged()
+
+      const pipeline = mongodb.aggregate.mock.calls[0].arguments[0]
+      assert.equal(pipeline.filter(s => s.$unionWith).length, 0)
     })
   })
 })

--- a/tests/utils-buildRecentlyChangedPipeline.spec.js
+++ b/tests/utils-buildRecentlyChangedPipeline.spec.js
@@ -1,0 +1,50 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import buildRecentlyChangedPipeline from '../lib/utils/buildRecentlyChangedPipeline.js'
+
+describe('buildRecentlyChangedPipeline()', () => {
+  it('should use the first collection as the base and union the rest', () => {
+    const pipeline = buildRecentlyChangedPipeline(['content', 'assets'])
+    const unions = pipeline.filter(s => s.$unionWith)
+    assert.equal(unions.length, 1)
+    assert.equal(unions[0].$unionWith.coll, 'assets')
+  })
+
+  it('should project the common row shape with a literal collection name per branch', () => {
+    const pipeline = buildRecentlyChangedPipeline(['content', 'assets'])
+    const baseProject = pipeline.find(s => s.$project).$project
+    assert.deepEqual(baseProject.collection, { $literal: 'content' })
+    assert.deepEqual(Object.keys(baseProject).sort(), ['_id', 'collection', 'createdAt', 'createdBy', 'updatedAt', 'updatedBy'].sort())
+
+    const unionProject = pipeline.find(s => s.$unionWith).$unionWith.pipeline.find(s => s.$project).$project
+    assert.deepEqual(unionProject.collection, { $literal: 'assets' })
+  })
+
+  it('should apply a per-collection filter as the branch $match', () => {
+    const filters = { content: { _type: 'course' } }
+    const pipeline = buildRecentlyChangedPipeline(['content', 'assets'], { filters })
+    assert.deepEqual(pipeline[0].$match, { _type: 'course' })
+    assert.deepEqual(pipeline.find(s => s.$unionWith).$unionWith.pipeline[0].$match, {})
+  })
+
+  it('should default the branch $match to an empty query when no filter is given', () => {
+    const pipeline = buildRecentlyChangedPipeline(['content'])
+    assert.deepEqual(pipeline[0].$match, {})
+  })
+
+  it('should sort by updatedAt descending and apply the limit', () => {
+    const pipeline = buildRecentlyChangedPipeline(['content'], { limit: 5 })
+    assert.deepEqual(pipeline.at(-2), { $sort: { updatedAt: -1 } })
+    assert.deepEqual(pipeline.at(-1), { $limit: 5 })
+  })
+
+  it('should default the limit to 25', () => {
+    const pipeline = buildRecentlyChangedPipeline(['content'])
+    assert.deepEqual(pipeline.at(-1), { $limit: 25 })
+  })
+
+  it('should produce no $unionWith stage for a single collection', () => {
+    const pipeline = buildRecentlyChangedPipeline(['content'])
+    assert.equal(pipeline.filter(s => s.$unionWith).length, 0)
+  })
+})


### PR DESCRIPTION
### Fixes #53

### New
* Add `getRecentlyChanged({ limit, filters })` — a registry-driven query returning the most-recently-changed documents across all registered collections (newest first), with per-collection filters applied at query time.
* Extract the pure aggregation-pipeline builder to `lib/utils/buildRecentlyChangedPipeline.js` (barrel `lib/utils.js`).

### Update
* Add an optional `updatedBy` field to the authored schema (legacy docs still validate).
* Stamp `updatedBy` with the acting user on every modifying request in `updateAuthor`, and thread it to the course root so deep content edits record the last editor on the course. Deletes bump `updatedAt` only (no acting user available).

### Testing
1. `npm test` — 51 pass (18 new).
2. `npx standard` — clean.