### PR TITLE
New: Add a createdBy ownership access grant (fixes #49)

### DIFF
--- a/lib/AuthoredModule.js
+++ b/lib/AuthoredModule.js
@@ -1,4 +1,5 @@
 import { AbstractModule, DataCache } from 'adapt-authoring-core'
+import { addAccessClause } from 'adapt-authoring-api'
 import { buildRecentlyChangedPipeline } from './utils.js'
 /**
  * Add supplementary data to existing schemas which defines how and when data was authored
@@ -38,9 +39,10 @@ class AuthoredModule extends AbstractModule {
    * Registers a module for use with this plugin
    * @param {AbstractApiModule} mod
    * @param {Object} options
-   * @param {Boolean} options.accessCheck Whether an access check should be performed
+   * @param {Boolean} [options.accessCheck=true] Whether to grant the creator ownership access to their own documents
    */
   async registerModule (mod, options = {}) {
+    const { accessCheck = true } = options
     if (this.registeredModules.includes(mod)) {
       throw this.app.errors.DUPL_AUTHORED_MODULE_NAME
         .setData({ name: mod.name })
@@ -63,6 +65,35 @@ class AuthoredModule extends AbstractModule {
     mod.preUpdateHook.tap((ogDoc, updateData) => this.updateTimestamps('update', updateData, updateData._courseId ?? ogDoc._courseId))
     // deletes carry no acting user, so bump the course timestamp only (no updatedBy)
     mod.preDeleteHook.tap((ogDoc) => this.updateCourseTimestamp({ _courseId: ogDoc._courseId }))
+
+    // grant the creator additive access to their own documents (owner dimension of _access)
+    if (accessCheck) {
+      mod.accessCheckHook.tap(this.grantCreatorItem)
+      mod.accessQueryHook.tap(this.grantCreatorQuery)
+    }
+  }
+
+  /**
+   * Per-item ownership grant (an `accessCheckHook` observer): grants access when the
+   * requesting user created the resource.
+   * @param {external:ExpressRequest} req
+   * @param {Object} resource
+   * @return {Boolean}
+   */
+  grantCreatorItem (req, resource) {
+    const _id = req.auth?.user?._id
+    return !!_id && resource?.createdBy === _id.toString()
+  }
+
+  /**
+   * Query-level ownership grant (an `accessQueryHook` observer): widens the query to include
+   * the requesting user's own documents so they aren't missing from list endpoints. Required
+   * alongside the per-item grant to keep pagination counts accurate. No-op when unauthenticated.
+   * @param {external:ExpressRequest} req
+   */
+  grantCreatorQuery (req) {
+    const _id = req.auth?.user?._id
+    if (_id) addAccessClause(req.apiData.query, { createdBy: _id.toString() })
   }
 
   /**

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "test": "node --test 'tests/**/*.spec.js'"
   },
   "dependencies": {
+    "adapt-authoring-api": "^4.0.1",
     "adapt-authoring-core": "^3.0.0"
   },
   "peerDependencies": {

--- a/tests/AuthoredModule.spec.js
+++ b/tests/AuthoredModule.spec.js
@@ -73,7 +73,9 @@ function createMockMod (opts = {}) {
     requestHook: { tap: mock.fn() },
     preInsertHook: { tap: mock.fn() },
     preUpdateHook: { tap: mock.fn() },
-    preDeleteHook: { tap: mock.fn() }
+    preDeleteHook: { tap: mock.fn() },
+    accessCheckHook: { tap: mock.fn() },
+    accessQueryHook: { tap: mock.fn() }
   }
 }
 
@@ -174,6 +176,28 @@ describe('AuthoredModule', () => {
       assert.equal(instance.registeredModules.length, 1)
     })
 
+    it('should tap the ownership access hooks by default', async () => {
+      const { instance } = createInstance()
+      const mod = createMockMod()
+
+      await instance.registerModule(mod)
+
+      assert.equal(mod.accessCheckHook.tap.mock.calls.length, 1)
+      assert.equal(mod.accessQueryHook.tap.mock.calls.length, 1)
+      assert.equal(mod.accessCheckHook.tap.mock.calls[0].arguments[0], AuthoredModule.prototype.grantCreatorItem)
+      assert.equal(mod.accessQueryHook.tap.mock.calls[0].arguments[0], AuthoredModule.prototype.grantCreatorQuery)
+    })
+
+    it('should not tap the access hooks when accessCheck is false', async () => {
+      const { instance } = createInstance()
+      const mod = createMockMod()
+
+      await instance.registerModule(mod, { accessCheck: false })
+
+      assert.equal(mod.accessCheckHook.tap.mock.calls.length, 0)
+      assert.equal(mod.accessQueryHook.tap.mock.calls.length, 0)
+    })
+
     it('should call registerSchemas after registering', async () => {
       const { instance, mockJsonschema } = createInstance()
       const mod = createMockMod({ schemaName: 'testSchema' })
@@ -221,6 +245,36 @@ describe('AuthoredModule', () => {
       await onDelete({ _courseId: 'course1', updatedBy: 'oldEditor' })
 
       assert.deepEqual(instance.updateCourseTimestamp.mock.calls[0].arguments[0], { _courseId: 'course1' })
+    })
+  })
+
+  describe('#grantCreatorItem()', () => {
+    const grant = AuthoredModule.prototype.grantCreatorItem
+    it('should grant access to the creator', () => {
+      assert.equal(grant({ auth: { user: { _id: 'u1' } } }, { createdBy: 'u1' }), true)
+    })
+    it('should not grant access to a non-creator', () => {
+      assert.equal(grant({ auth: { user: { _id: 'u2' } } }, { createdBy: 'u1' }), false)
+    })
+    it('should not grant when unauthenticated', () => {
+      assert.equal(grant({ auth: {} }, { createdBy: 'u1' }), false)
+    })
+    it('should not grant when the resource has no createdBy', () => {
+      assert.equal(grant({ auth: { user: { _id: 'u1' } } }, {}), false)
+    })
+  })
+
+  describe('#grantCreatorQuery()', () => {
+    const grant = AuthoredModule.prototype.grantCreatorQuery
+    it('should widen the query with the creator id', () => {
+      const query = {}
+      grant({ auth: { user: { _id: 'u1' } }, apiData: { query } })
+      assert.deepEqual(query.$or, [{ createdBy: 'u1' }])
+    })
+    it('should be a no-op when unauthenticated', () => {
+      const query = {}
+      grant({ auth: {}, apiData: { query } })
+      assert.deepEqual(query, {})
     })
   })
 


### PR DESCRIPTION
### Fixes #49

### New
- `registerModule` now grants the creator additive access to their own documents (the ownership dimension of `_access`), gated by the existing `options.accessCheck` (default `true`; pass `false` to opt out, as assets does):
  - `accessCheckHook` — per item: grant when `resource.createdBy === req.auth.user._id`.
  - `accessQueryHook` — query level: `addAccessClause(req.apiData.query, { createdBy: req.auth.user._id.toString() })`, so a user's own private documents aren't dropped from list endpoints (keeps pagination counts accurate).
- Implements the previously documented-but-unimplemented `accessCheck` option.
- Add `adapt-authoring-api ^4.0.1` to dependencies (for `addAccessClause`).

### Testing
- New `grantCreatorItem` / `grantCreatorQuery` specs and `registerModule` hook-tapping tests (default taps both hooks; `accessCheck: false` taps neither) — 59 unit tests pass; `npx standard` clean.

### Notes
- Part of the `_access` rollout (api #98). Moves ownership out of adaptframework's hardcoded `checkContentAccess`, so it should land together with adaptframework #194 (which removes the duplicate) and the assets/content enablement — the coordinated umbrella release.
