### PR TITLE
Fix: compare createdBy as string in creator access grant (fixes #56)

### DIFF
--- a/lib/AuthoredModule.js
+++ b/lib/AuthoredModule.js
@@ -82,7 +82,7 @@ class AuthoredModule extends AbstractModule {
    */
   grantCreatorItem (req, resource) {
     const _id = req.auth?.user?._id
-    return !!_id && resource?.createdBy === _id.toString()
+    return !!_id && !!resource?.createdBy && String(resource.createdBy) === String(_id)
   }
 
   /**


### PR DESCRIPTION
### Fixes #56

### Fix
* `grantCreatorItem` compared an ObjectId `createdBy` against a stringified user id with `===` (always false). Normalise both sides with `String()` so the per-item creator grant matches and a user's own documents survive access filtering.
