### PR TITLE
New: block deleting content owners; add ownership transfer (fixes #58)

### DIFF
--- a/errors/errors.json
+++ b/errors/errors.json
@@ -6,5 +6,14 @@
   "INVALID_CREATED_BY": {
     "description": "The specified createdBy user does not exist",
     "statusCode": 400
+  },
+  "USER_OWNS_CONTENT": {
+    "data": {
+      "_id": "_id of the user",
+      "total": "Total number of documents owned by the user",
+      "counts": "Map of collection name to owned-document count"
+    },
+    "description": "The user cannot be deleted because they still own content; transfer it to another user first",
+    "statusCode": 400
   }
 }

--- a/lib/AuthoredModule.js
+++ b/lib/AuthoredModule.js
@@ -191,6 +191,24 @@ class AuthoredModule extends AbstractModule {
   }
 
   /**
+   * Lists the courses and assets owned (via `createdBy`) by a user, for a transfer preview.
+   * @param {String} userId
+   * @return {Promise<Object>} `{ courses: [{_id,title}], assets: [{_id,title}] }`
+   */
+  async getOwnedSummary (userId) {
+    const mongodb = await this.app.waitForModule('mongodb')
+    const createdBy = userId.toString()
+    const [courses, assets] = await Promise.all([
+      mongodb.find('content', { createdBy, _type: 'course' }, { projection: { title: 1, displayTitle: 1 } }),
+      mongodb.find('assets', { createdBy }, { projection: { title: 1 } })
+    ])
+    return {
+      courses: courses.map(c => ({ _id: c._id, title: c.title || c.displayTitle || String(c._id) })),
+      assets: assets.map(a => ({ _id: a._id, title: a.title || String(a._id) }))
+    }
+  }
+
+  /**
    * Reassigns ownership of every document created by one user to another, across all registered
    * collections. Only `createdBy` is changed; sharing grants and timestamps are left untouched.
    * @param {String} fromUserId The current owner

--- a/lib/AuthoredModule.js
+++ b/lib/AuthoredModule.js
@@ -33,6 +33,9 @@ class AuthoredModule extends AbstractModule {
 
     const jsonschema = await this.app.waitForModule('jsonschema')
     jsonschema.registerSchemasHook.tap(this.registerSchemas.bind(this))
+
+    const users = await this.app.waitForModule('users')
+    users.preDeleteHook.tap(this.blockOwnerDelete.bind(this))
   }
 
   /**
@@ -156,6 +159,56 @@ class AuthoredModule extends AbstractModule {
     const $set = { updatedAt: new Date().toISOString() }
     if (data.updatedBy) $set.updatedBy = data.updatedBy
     await mongodb.update('content', { _id: course._id }, { $set })
+  }
+
+  /**
+   * Refuses deletion of a user who still owns authored content, preventing orphaned documents.
+   * Tapped on the users module's `preDeleteHook`.
+   * @param {Object} user The user document about to be deleted
+   * @return {Promise}
+   */
+  async blockOwnerDelete (user) {
+    const counts = await this.getOwnedCounts(user._id)
+    const total = Object.values(counts).reduce((sum, n) => sum + n, 0)
+    if (total > 0) {
+      throw this.app.errors.USER_OWNS_CONTENT.setData({ _id: user._id.toString(), total, counts })
+    }
+  }
+
+  /**
+   * Counts the documents owned (via `createdBy`) by a user in every registered collection.
+   * @param {String} userId
+   * @return {Promise<Object>} Map of collection name to owned-document count
+   */
+  async getOwnedCounts (userId) {
+    const mongodb = await this.app.waitForModule('mongodb')
+    const createdBy = userId.toString()
+    const counts = {}
+    for (const mod of this.registeredModules) {
+      if (mod.collectionName) counts[mod.collectionName] = await mongodb.count(mod.collectionName, { createdBy })
+    }
+    return counts
+  }
+
+  /**
+   * Reassigns ownership of every document created by one user to another, across all registered
+   * collections. Only `createdBy` is changed; sharing grants and timestamps are left untouched.
+   * @param {String} fromUserId The current owner
+   * @param {String} toUserId The new owner
+   * @return {Promise<Object>} Map of collection name to number of documents reassigned
+   */
+  async transferOwnership (fromUserId, toUserId) {
+    const mongodb = await this.app.waitForModule('mongodb')
+    const from = fromUserId.toString()
+    const to = toUserId.toString()
+    const moved = {}
+    for (const mod of this.registeredModules) {
+      if (!mod.collectionName) continue
+      const count = await mongodb.count(mod.collectionName, { createdBy: from })
+      if (count) await mongodb.updateMany(mod.collectionName, { createdBy: from }, { $set: { createdBy: to } })
+      moved[mod.collectionName] = count
+    }
+    return moved
   }
 
   /**


### PR DESCRIPTION
### Fixes #58

### New
- Tap the users module's `preDeleteHook` to refuse deleting a user who still owns documents in any registered collection, throwing `USER_OWNS_CONTENT` with per-collection counts and a total.
- Add `transferOwnership(fromUserId, toUserId)` to reassign `createdBy` across every registered collection, so a user's content can be moved to another user before deletion. Only `createdBy` is changed — sharing grants and timestamps are left untouched.

### Testing
- Seeded documents in every registered collection with `createdBy = userA` against a live database:
  - `getOwnedCounts(userA)` → per-collection counts
  - deleting userA → throws `USER_OWNS_CONTENT`
  - `transferOwnership(A→B)` → reassigns all of them (verified the sample doc's `createdBy` is now userB)
  - deleting userA → now succeeds
- `npx standard` clean.
